### PR TITLE
chore(Amplify-Migration): Update permalinks

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,8 +1,16 @@
 logo: /images/favicon-isomer.ico
 links:
-  - title: asdadfdsfjsdgkjdslgdsf
-    url: /contact-us/
-  - title: asdadfdsfjsdgkjdslgfdsgfd
-    url: /Sample/
-  - title: Menu Title
+  - title: Folder
     collection: fdsfs
+  - title: Resource Room
+    resource_room: true
+  - title: Single page
+    url: /fdsfs/LINKWITHCAPS/permalink
+  - title: SubMenu
+    url: /fdsfs/LINKWITHCAPS/permalink/
+    sublinks:
+      - title: Submenu Title
+        url: /fdsfs/LINKWITHCAPS/permalink/
+    sublinks:
+      - title: Submenu Title
+        url: fdsfs/LINKWITHCAPS/permalink/

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -5,12 +5,12 @@ links:
   - title: Resource Room
     resource_room: true
   - title: Single page
-    url: /fdsfs/LINKWITHCAPS/permalink
+    url: /fdsfs/linkwithcaps/permalink
   - title: SubMenu
-    url: /fdsfs/LINKWITHCAPS/permalink/
+    url: /fdsfs/linkwithcaps/permalink/
     sublinks:
       - title: Submenu Title
-        url: /fdsfs/LINKWITHCAPS/permalink/
+        url: /fdsfs/linkwithcaps/permalink/
     sublinks:
       - title: Submenu Title
-        url: fdsfs/LINKWITHCAPS/permalink/
+        url: fdsfs/linkwithcaps/permalink/

--- a/_fdsfs/Dsfasdgfdgfds/Example Title.md
+++ b/_fdsfs/Dsfasdgfdgfds/Example Title.md
@@ -1,23 +1,23 @@
 ---
 title: Example Title
-permalink: /fdsfs/Dsfasdgfdgfds/permalink/
+permalink: /fdsfs/dsfasdgfdgfds/permalink/
 description: ""
 third_nav_title: Dsfasdgfdgfds
 ---
 
-<a href="/fdsfs/LINKWITHCAPS/permalink/"></a>
-<a href="/fdsfs/LINKWITHCAPS/permalink"></a>
-<a href="/fdsfs/LINKWITHCAPS/permalink"></a>
-<a href="/fdsfs/LINKWITHCAPS/permalink/"></a>
-<a href="fdsfs/LINKWITHCAPS/permalink"></a>
-<a href="fdsfs/LINKWITHCAPS/permalink/"></a>
-<a href='fdsfs/LINKWITHCAPS/permalink'></a>
-<a href='fdsfs/LINKWITHCAPS/permalink/'></a>
+<a href="/fdsfs/linkwithcaps/permalink/"></a>
+<a href="/fdsfs/linkwithcaps/permalink"></a>
+<a href="/fdsfs/linkwithcaps/permalink"></a>
+<a href="/fdsfs/linkwithcaps/permalink/"></a>
+<a href="fdsfs/linkwithcaps/permalink"></a>
+<a href="fdsfs/linkwithcaps/permalink/"></a>
+<a href="fdsfs/linkwithcaps/permalink"></a>
+<a href="fdsfs/linkwithcaps/permalink/"></a>
 
-[clickme](/fdsfs/LINKWITHCAPS/permalink)
-[clickme](/fdsfs/LINKWITHCAPS/permalink/)
-[clickme](fdsfs/LINKWITHCAPS/permalink)
-[clickme](fdsfs/LINKWITHCAPS/permalink/)
+[clickme](/fdsfs/linkwithcaps/permalink)
+[clickme](/fdsfs/linkwithcaps/permalink/)
+[clickme](fdsfs/linkwithcaps/permalink)
+[clickme](fdsfs/linkwithcaps/permalink/)
 
 not supposed to change the files below
 <a href="/fdsfs/LINKWITHCAPS/permalink.pdf"></a>

--- a/_fdsfs/Dsfasdgfdgfds/Example Titlefsaf.md
+++ b/_fdsfs/Dsfasdgfdgfds/Example Titlefsaf.md
@@ -1,6 +1,6 @@
 ---
 title: Example Titlefsaf
-permalink: /fdsfs/Dsfasdgfdgfds/permalink/
+permalink: /fdsfs/dsfasdgfdgfds/permalink/
 description: ""
 third_nav_title: Dsfasdgfdgfds
 ---

--- a/_fdsfs/LINKWITHCAPS/PAGEWITHCAPS.md
+++ b/_fdsfs/LINKWITHCAPS/PAGEWITHCAPS.md
@@ -1,6 +1,6 @@
 ---
 title: PAGEWITHCAPS
-permalink: /fdsfs/LINKWITHCAPS/permalink/
+permalink: /fdsfs/linkwithcaps/permalink/
 description: ""
 third_nav_title: LINKWITHCAPS
 ---


### PR DESCRIPTION
This PR is meant to be an example of changes a repo would go through with regards to permalinks as we migrate from netlify to amplity. This is meant to be a simple sanity check on what cases the migration code currently covers.